### PR TITLE
Restart Apache only if it was actually started, be it system or homebrew

### DIFF
--- a/sphp
+++ b/sphp
@@ -24,9 +24,18 @@ if [ $? -eq 0 ]; then
 
 	echo "Updating version file..."
 
-	echo "Restarting Apache..."
-	sudo pkill -9 httpd
-	sudo apachectl -k restart > /dev/null 2>&1
+	pgrep -f /usr/sbin/httpd 2> /dev/null > /dev/null
+	if [ $? -eq 0 ]; then
+		echo "Restarting system Apache..."
+		sudo pkill -9 -f /usr/sbin/httpd
+		sudo /usr/sbin/apachectl -k restart > /dev/null 2>&1
+	fi
+	pgrep -f /usr/local/Cellar/*/httpd 2> /dev/null > /dev/null
+	if [ $? -eq 0 ]; then
+		echo "Restarting homebrew Apache..."
+		sudo pkill -9 -f /usr/local/Cellar/*/httpd
+		sudo /usr/local/bin/apachectl -k restart > /dev/null 2>&1
+	fi
 
 	echo "Done."
 else


### PR DESCRIPTION
Howdy.

This is a simple patch that "fixes" two "issues":
1. It only kills/starts Apache if Apache was actually running already,
2. It only kills/starts the system Apache or a homebrew Apache.

This should not affect any `sphp` users. However, it should help people who are running full AMP solution stacks such as MAMP, XAMPP, or AMPPS. These stacks already bundle Apache & PHP. It is possible for somebody to be running MAMP with a specific PHP version (say 5.4), while using a different, more recent, homebrew PHP as a command-line tool (say 5.6). In that scenario, `sphp` would kill MAMP's `httpd` process unnecessarily, then restart the (wrong) *system's* `httpd` or homebrew's `httpd` (if installed). 

This patch prevents this situation from happening by only killing and restarting the system's or homebrew's `httpd`. Furthermore, it first uses `pgrep` to test for `httpd`, thus avoiding a `sudo` when none is needed.

Thanks 
