### PR TITLE
Support for PHP7

### DIFF
--- a/sphp
+++ b/sphp
@@ -11,7 +11,6 @@ newversion="$1"
 shortOld="`php -r \"echo substr(phpversion(), 0, 1);\"`"
 shortNew="`php -r \"echo substr('$1', 0, 1);\"`"
 
-echo $majorNewVersion
 brew list php$newversion 2> /dev/null > /dev/null
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
Hello,
with this change, you can now have both `php5_module` and `php7_module` in the `httpd.conf` and `sphp` will take care of commenting/uncommenting the modules based on the version.

```
$ sphp 70

#LoadModule php5_module /usr/local/lib/libphp5.so
LoadModule php7_module /usr/local/lib/libphp7.so
```

```
$ sphp 56

LoadModule php5_module /usr/local/lib/libphp5.so
#LoadModule php7_module /usr/local/lib/libphp7.so
```